### PR TITLE
Lock to 1.85 for Valgrind.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-          toolchain: stable minus 2 releases
+          toolchain: 1.85
       - name: Test gnu
         run: |
           cargo test --all-features --no-fail-fast --target ${{ matrix.target }}
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable minus 2 releases
+          toolchain: 1.85
       - name: 64-bit Valgrind
         run: |
           cargo build --examples
@@ -92,7 +92,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-          toolchain: stable minus 2 releases
+          toolchain: 1.85
       - name: Build gnu target
         run: |
           cargo build --all-features --target ${{ matrix.target }}
@@ -113,7 +113,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-          toolchain: stable minus 2 releases
+          toolchain: 1.85
       - name: Build Windows
         run: |
           cargo build --all-features --target ${{ matrix.target }}
@@ -133,7 +133,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-          toolchain: stable minus 2 releases
+          toolchain: 1.85
       - name: Test Windows
         run: |
           cargo test --all-features --no-fail-fast --target ${{ matrix.target }}
@@ -168,7 +168,7 @@ jobs:
         - uses: dtolnay/rust-toolchain@stable
           with:
             components: clippy
-            toolchain: stable minus 2 releases
+            toolchain: 1.85
         - run: cargo clippy --all-features -- --deny warnings
         - run: cargo clippy --no-default-features -- --deny warnings
         - run: cargo clippy --examples -- --deny warnings -A clippy::unwrap-used -A clippy::missing_docs_in_private_items


### PR DESCRIPTION
Same issue we had on tii. Locking to `1.85`. You can see CI failing with just an empty commit here
https://github.com/tiipotto/trivial_log/commit/818cf81a40c21bfeda0b8c76b82725e1a0abcdbf